### PR TITLE
download edk2 firmware rather than using the system provided one

### DIFF
--- a/.build/CascadeTarget.zig
+++ b/.build/CascadeTarget.zig
@@ -134,18 +134,26 @@ pub const CascadeTarget = enum {
         }
     }
 
-    pub fn uefiFirmwarePath(self: CascadeTarget) ![]const u8 {
+    pub const FirmwareUris = struct {
+        code: std.Uri,
+        vars: std.Uri,
+    };
+
+    pub fn uefiFirmwareUris(self: CascadeTarget) !FirmwareUris {
         switch (self) {
             .aarch64 => {
-                if (helpers.fileExists("/usr/share/edk2/aarch64/QEMU_EFI.fd")) return "/usr/share/edk2/aarch64/QEMU_EFI.fd";
+                return .{
+                    .code = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_EFI.fd"),
+                    .vars = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_VARS.fd"),
+                };
             },
             .x86_64 => {
-                if (helpers.fileExists("/usr/share/ovmf/x64/OVMF.fd")) return "/usr/share/ovmf/x64/OVMF.fd";
-                if (helpers.fileExists("/usr/share/ovmf/OVMF.fd")) return "/usr/share/ovmf/OVMF.fd";
+                return .{
+                    .code = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF_CODE.fd"),
+                    .vars = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF_VARS.fd"),
+                };
             },
         }
-
-        return error.UnableToLocateUefiFirmware;
     }
 
     pub fn targetSpecificSetup(self: CascadeTarget, kernel_exe: *Step.Compile) void {

--- a/.build/CascadeTarget.zig
+++ b/.build/CascadeTarget.zig
@@ -139,21 +139,11 @@ pub const CascadeTarget = enum {
         vars: std.Uri,
     };
 
-    pub fn uefiFirmwareUris(self: CascadeTarget) !FirmwareUris {
-        switch (self) {
-            .aarch64 => {
-                return .{
-                    .code = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_EFI.fd"),
-                    .vars = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_VARS.fd"),
-                };
-            },
-            .x86_64 => {
-                return .{
-                    .code = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF_CODE.fd"),
-                    .vars = try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF_VARS.fd"),
-                };
-            },
-        }
+    pub fn uefiFirmwareUri(self: CascadeTarget) !std.Uri {
+        return switch (self) {
+            .aarch64 => try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_EFI.fd"),
+            .x86_64 => try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF.fd"),
+        };
     }
 
     pub fn targetSpecificSetup(self: CascadeTarget, kernel_exe: *Step.Compile) void {

--- a/.build/CascadeTarget.zig
+++ b/.build/CascadeTarget.zig
@@ -108,7 +108,7 @@ pub const CascadeTarget = enum {
         };
     }
 
-    pub fn buildImagePath(self: CascadeTarget, b: *std.Build) []const u8 {
+    pub fn buildImageScriptPath(self: CascadeTarget, b: *std.Build) []const u8 {
         _ = self;
         return helpers.pathJoinFromRoot(b, &.{ ".build", "build_limine_image.sh" });
     }
@@ -134,15 +134,10 @@ pub const CascadeTarget = enum {
         }
     }
 
-    pub const FirmwareUris = struct {
-        code: std.Uri,
-        vars: std.Uri,
-    };
-
-    pub fn uefiFirmwareUri(self: CascadeTarget) !std.Uri {
+    pub fn uefiFirmwareUrl(self: CascadeTarget) []const u8 {
         return switch (self) {
-            .aarch64 => try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_EFI.fd"),
-            .x86_64 => try std.Uri.parse("https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF.fd"),
+            .aarch64 => "https://retrage.github.io/edk2-nightly/bin/RELEASEAARCH64_QEMU_EFI.fd",
+            .x86_64 => "https://retrage.github.io/edk2-nightly/bin/RELEASEX64_OVMF.fd",
         };
     }
 

--- a/.build/EDK2Step.zig
+++ b/.build/EDK2Step.zig
@@ -10,16 +10,12 @@ const EDK2Step = @This();
 step: Step,
 target: CascadeTarget,
 
-code_firmware: std.Build.GeneratedFile,
-code_firmware_source: std.Build.FileSource,
-
-vars_firmware: std.Build.GeneratedFile,
-vars_firmware_source: std.Build.FileSource,
+firmware: std.Build.GeneratedFile,
+firmware_source: std.Build.FileSource,
 
 timestamp_file_path: []const u8,
 edk2_path: []const u8,
-code_path: []const u8,
-var_path: []const u8,
+firmware_path: []const u8,
 
 pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
     const self = try b.allocator.create(EDK2Step);
@@ -34,10 +30,8 @@ pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
             .makeFn = make,
         }),
         .target = target,
-        .code_firmware = undefined,
-        .code_firmware_source = undefined,
-        .vars_firmware = undefined,
-        .vars_firmware_source = undefined,
+        .firmware = undefined,
+        .firmware_source = undefined,
         .timestamp_file_path = try b.cache_root.join(
             b.allocator,
             &.{
@@ -49,19 +43,13 @@ pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
             },
         ),
         .edk2_path = try b.cache_root.join(b.allocator, &.{"edk2"}),
-        .code_path = try b.cache_root.join(b.allocator, &.{
+        .firmware_path = try b.cache_root.join(b.allocator, &.{
             "edk2",
-            try std.fmt.allocPrint(b.allocator, "CODE-{s}.fd", .{@tagName(self.target)}),
-        }),
-        .var_path = try b.cache_root.join(b.allocator, &.{
-            "edk2",
-            try std.fmt.allocPrint(b.allocator, "VAR-{s}.fd", .{@tagName(self.target)}),
+            try std.fmt.allocPrint(b.allocator, "OVMF-{s}.fd", .{@tagName(self.target)}),
         }),
     };
-    self.code_firmware = .{ .step = &self.step };
-    self.code_firmware_source = .{ .generated = &self.code_firmware };
-    self.vars_firmware = .{ .step = &self.step };
-    self.vars_firmware_source = .{ .generated = &self.vars_firmware };
+    self.firmware = .{ .step = &self.step };
+    self.firmware_source = .{ .generated = &self.firmware };
 
     return self;
 }
@@ -70,43 +58,36 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     var node = prog_node.start(step.name, 0);
     defer node.end();
 
-    const b = step.owner;
+    node.activate();
+
     const self = @fieldParentPtr(EDK2Step, "step", step);
 
     if (!self.needToDownloadFirmware()) {
-        self.code_firmware.path = self.code_path;
-        self.vars_firmware.path = self.var_path;
+        self.firmware.path = self.firmware_path;
         step.result_cached = true;
         return;
     }
 
-    const firmware_uris = try self.target.uefiFirmwareUris();
+    const firmware_uri = try self.target.uefiFirmwareUri();
 
     try std.fs.cwd().makePath(self.edk2_path);
 
-    var client: std.http.Client = .{ .allocator = b.allocator };
-    defer client.deinit();
+    try fetch(step, firmware_uri, self.firmware_path);
 
-    try self.fetch(&client, firmware_uris.code, self.code_path);
-
-    try self.fetch(&client, firmware_uris.vars, self.var_path);
-
-    self.code_firmware.path = self.code_path;
-    self.vars_firmware.path = self.var_path;
+    self.firmware.path = self.firmware_path;
 
     try self.updateTimestampFile();
 }
 
-// 6 hours
-const timeout_ns = std.time.ns_per_hour * 6;
+// 24 hours
+const cache_validity_period = std.time.ns_per_hour * 24;
 
 fn needToDownloadFirmware(self: *EDK2Step) bool {
-    std.fs.accessAbsolute(self.code_path, .{}) catch return true;
-    std.fs.accessAbsolute(self.var_path, .{}) catch return true;
+    std.fs.accessAbsolute(self.firmware_path, .{}) catch return true;
     const timestamp_file = std.fs.cwd().openFile(self.timestamp_file_path, .{}) catch return true;
     defer timestamp_file.close();
     const stat = timestamp_file.stat() catch return true;
-    return std.time.nanoTimestamp() >= stat.mtime + timeout_ns;
+    return std.time.nanoTimestamp() >= stat.mtime + cache_validity_period;
 }
 
 fn updateTimestampFile(self: *EDK2Step) !void {
@@ -116,38 +97,39 @@ fn updateTimestampFile(self: *EDK2Step) !void {
     try timestamp_file.updateTimes(stat.atime, std.time.nanoTimestamp());
 }
 
-fn fetch(self: *EDK2Step, client: *std.http.Client, uri: std.Uri, destination_path: []const u8) !void {
+fn fetch(step: *Step, uri: std.Uri, destination_path: []const u8) !void {
     const file = try std.fs.cwd().createFile(destination_path, .{});
     defer file.close();
 
-    var buffer_writer = std.io.bufferedWriter(file.writer());
+    var buffered_writer = std.io.bufferedWriter(file.writer());
 
-    var h = std.http.Headers{ .allocator = client.allocator };
-    defer h.deinit();
+    downloadWithHttpClient(step.owner.allocator, uri, buffered_writer.writer()) catch |err| {
+        return step.fail("failed to fetch '{s}': {s}", .{ uri, @errorName(err) });
+    };
 
-    var req = try client.request(.GET, uri, h, .{});
+    try buffered_writer.flush();
+}
+
+fn downloadWithHttpClient(allocator: std.mem.Allocator, uri: std.Uri, writer: anytype) !void {
+    var client: std.http.Client = .{ .allocator = allocator };
+    defer client.deinit();
+
+    var headers = std.http.Headers{ .allocator = allocator };
+    defer headers.deinit();
+
+    var req = try client.request(.GET, uri, headers, .{});
     defer req.deinit();
 
     try req.start();
     try req.wait();
 
-    if (req.response.status != .ok) return self.step.fail("failed to fetch: {s}", .{uri});
+    if (req.response.status != .ok) return error.ResponseNotOk;
 
     var buffer: [4096]u8 = undefined;
 
     while (true) {
         const number_read = try req.reader().read(&buffer);
         if (number_read == 0) break;
-        try buffer_writer.writer().writeAll(buffer[0..number_read]);
-    }
-
-    try buffer_writer.flush();
-
-    if (self.target == .aarch64) {
-        // QEMU requires the firmware to be at least 64 MiB in size for aarch64
-        const minimum_size = 67108864; // 64 MiB
-        if (try file.getEndPos() < minimum_size) {
-            try file.setEndPos(minimum_size);
-        }
+        try writer.writeAll(buffer[0..number_read]);
     }
 }

--- a/.build/EDK2Step.zig
+++ b/.build/EDK2Step.zig
@@ -16,6 +16,11 @@ code_firmware_source: std.Build.FileSource,
 vars_firmware: std.Build.GeneratedFile,
 vars_firmware_source: std.Build.FileSource,
 
+timestamp_file_path: []const u8,
+edk2_path: []const u8,
+code_path: []const u8,
+var_path: []const u8,
+
 pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
     const self = try b.allocator.create(EDK2Step);
 
@@ -33,6 +38,25 @@ pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
         .code_firmware_source = undefined,
         .vars_firmware = undefined,
         .vars_firmware_source = undefined,
+        .timestamp_file_path = try b.cache_root.join(
+            b.allocator,
+            &.{
+                try std.fmt.allocPrint(
+                    b.allocator,
+                    "edk2_timestamp_{s}",
+                    .{@tagName(target)},
+                ),
+            },
+        ),
+        .edk2_path = try b.cache_root.join(b.allocator, &.{"edk2"}),
+        .code_path = try b.cache_root.join(b.allocator, &.{
+            "edk2",
+            try std.fmt.allocPrint(b.allocator, "CODE-{s}.fd", .{@tagName(self.target)}),
+        }),
+        .var_path = try b.cache_root.join(b.allocator, &.{
+            "edk2",
+            try std.fmt.allocPrint(b.allocator, "VAR-{s}.fd", .{@tagName(self.target)}),
+        }),
     };
     self.code_firmware = .{ .step = &self.step };
     self.code_firmware_source = .{ .generated = &self.code_firmware };
@@ -48,31 +72,50 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     const b = step.owner;
     const self = @fieldParentPtr(EDK2Step, "step", step);
 
+    if (!self.needToDownloadFirmware()) {
+        self.code_firmware.path = self.code_path;
+        self.vars_firmware.path = self.var_path;
+        step.result_cached = true;
+        return;
+    }
+
     const firmware_uris = try self.target.uefiFirmwareUris();
 
-    const edk2_directory = try b.cache_root.join(b.allocator, &.{"edk2"});
-    try std.fs.cwd().makePath(edk2_directory);
+    try std.fs.cwd().makePath(self.edk2_path);
 
     var client: std.http.Client = .{ .allocator = b.allocator };
     defer client.deinit();
 
-    const code_path = try b.cache_root.join(b.allocator, &.{
-        "edk2",
-        try std.fmt.allocPrint(b.allocator, "CODE-{s}.fd", .{@tagName(self.target)}),
-    });
-    try fetch(step, &client, firmware_uris.code, code_path);
+    try self.fetch(&client, firmware_uris.code, self.code_path);
 
-    const vars_path = try b.cache_root.join(b.allocator, &.{
-        "edk2",
-        try std.fmt.allocPrint(b.allocator, "VARS-{s}.fd", .{@tagName(self.target)}),
-    });
-    try fetch(step, &client, firmware_uris.vars, vars_path);
+    try self.fetch(&client, firmware_uris.vars, self.var_path);
 
-    self.code_firmware.path = code_path;
-    self.vars_firmware.path = vars_path;
+    self.code_firmware.path = self.code_path;
+    self.vars_firmware.path = self.var_path;
+
+    try self.updateTimestampFile();
 }
 
-fn fetch(step: *Step, client: *std.http.Client, uri: std.Uri, destination_path: []const u8) !void {
+// 6 hours
+const timeout_ns = std.time.ns_per_hour * 6;
+
+fn needToDownloadFirmware(self: *EDK2Step) bool {
+    std.fs.accessAbsolute(self.code_path, .{}) catch return true;
+    std.fs.accessAbsolute(self.var_path, .{}) catch return true;
+    const timestamp_file = std.fs.cwd().openFile(self.timestamp_file_path, .{}) catch return true;
+    defer timestamp_file.close();
+    const stat = timestamp_file.stat() catch return true;
+    return std.time.nanoTimestamp() >= stat.mtime + timeout_ns;
+}
+
+fn updateTimestampFile(self: *EDK2Step) !void {
+    const timestamp_file = try std.fs.cwd().createFile(self.timestamp_file_path, .{});
+    defer timestamp_file.close();
+    const stat = try timestamp_file.stat();
+    try timestamp_file.updateTimes(stat.atime, std.time.nanoTimestamp());
+}
+
+fn fetch(self: *EDK2Step, client: *std.http.Client, uri: std.Uri, destination_path: []const u8) !void {
     const file = try std.fs.cwd().createFile(destination_path, .{});
     defer file.close();
 
@@ -87,7 +130,7 @@ fn fetch(step: *Step, client: *std.http.Client, uri: std.Uri, destination_path: 
     try req.start();
     try req.wait();
 
-    if (req.response.status != .ok) return step.fail("failed to fetch: {s}", .{uri});
+    if (req.response.status != .ok) return self.step.fail("failed to fetch: {s}", .{uri});
 
     var buffer: [4096]u8 = undefined;
 
@@ -99,9 +142,11 @@ fn fetch(step: *Step, client: *std.http.Client, uri: std.Uri, destination_path: 
 
     try buffer_writer.flush();
 
-    // QEMU requires the firmware to be at least 64 MiB in size (at least for aarch64)
-    const minimum_size = 67108864; // 64 MiB
-    if (try file.getEndPos() < minimum_size) {
-        try file.setEndPos(minimum_size);
+    if (self.target == .aarch64) {
+        // QEMU requires the firmware to be at least 64 MiB in size for aarch64
+        const minimum_size = 67108864; // 64 MiB
+        if (try file.getEndPos() < minimum_size) {
+            try file.setEndPos(minimum_size);
+        }
     }
 }

--- a/.build/EDK2Step.zig
+++ b/.build/EDK2Step.zig
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+
+const std = @import("std");
+const Step = std.Build.Step;
+
+const CascadeTarget = @import("CascadeTarget.zig").CascadeTarget;
+
+const EDK2Step = @This();
+
+step: Step,
+target: CascadeTarget,
+
+code_firmware: std.Build.GeneratedFile,
+code_firmware_source: std.Build.FileSource,
+
+vars_firmware: std.Build.GeneratedFile,
+vars_firmware_source: std.Build.FileSource,
+
+pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
+    const self = try b.allocator.create(EDK2Step);
+
+    const name = try std.fmt.allocPrint(b.allocator, "fetch EDK2 firmware for {s}", .{@tagName(target)});
+
+    self.* = .{
+        .step = Step.init(.{
+            .id = .custom,
+            .name = name,
+            .owner = b,
+            .makeFn = make,
+        }),
+        .target = target,
+        .code_firmware = undefined,
+        .code_firmware_source = undefined,
+        .vars_firmware = undefined,
+        .vars_firmware_source = undefined,
+    };
+    self.code_firmware = .{ .step = &self.step };
+    self.code_firmware_source = .{ .generated = &self.code_firmware };
+    self.vars_firmware = .{ .step = &self.step };
+    self.vars_firmware_source = .{ .generated = &self.vars_firmware };
+
+    return self;
+}
+
+fn make(step: *Step, prog_node: *std.Progress.Node) !void {
+    _ = prog_node;
+
+    const b = step.owner;
+    const self = @fieldParentPtr(EDK2Step, "step", step);
+
+    const firmware_uris = try self.target.uefiFirmwareUris();
+
+    const edk2_directory = try b.cache_root.join(b.allocator, &.{"edk2"});
+    try std.fs.cwd().makePath(edk2_directory);
+
+    var client: std.http.Client = .{ .allocator = b.allocator };
+    defer client.deinit();
+
+    const code_path = try b.cache_root.join(b.allocator, &.{
+        "edk2",
+        try std.fmt.allocPrint(b.allocator, "CODE-{s}.fd", .{@tagName(self.target)}),
+    });
+    try fetch(step, &client, firmware_uris.code, code_path);
+
+    const vars_path = try b.cache_root.join(b.allocator, &.{
+        "edk2",
+        try std.fmt.allocPrint(b.allocator, "VARS-{s}.fd", .{@tagName(self.target)}),
+    });
+    try fetch(step, &client, firmware_uris.vars, vars_path);
+
+    self.code_firmware.path = code_path;
+    self.vars_firmware.path = vars_path;
+}
+
+fn fetch(step: *Step, client: *std.http.Client, uri: std.Uri, destination_path: []const u8) !void {
+    const file = try std.fs.cwd().createFile(destination_path, .{});
+    defer file.close();
+
+    var buffer_writer = std.io.bufferedWriter(file.writer());
+
+    var h = std.http.Headers{ .allocator = client.allocator };
+    defer h.deinit();
+
+    var req = try client.request(.GET, uri, h, .{});
+    defer req.deinit();
+
+    try req.start();
+    try req.wait();
+
+    if (req.response.status != .ok) return step.fail("failed to fetch: {s}", .{uri});
+
+    var buffer: [4096]u8 = undefined;
+
+    while (true) {
+        const number_read = try req.reader().read(&buffer);
+        if (number_read == 0) break;
+        try buffer_writer.writer().writeAll(buffer[0..number_read]);
+    }
+
+    try buffer_writer.flush();
+
+    // QEMU requires the firmware to be at least 64 MiB in size (at least for aarch64)
+    const minimum_size = 67108864; // 64 MiB
+    if (try file.getEndPos() < minimum_size) {
+        try file.setEndPos(minimum_size);
+    }
+}

--- a/.build/EDK2Step.zig
+++ b/.build/EDK2Step.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const Step = std.Build.Step;
 
 const CascadeTarget = @import("CascadeTarget.zig").CascadeTarget;
+const helpers = @import("helpers.zig");
 
 const EDK2Step = @This();
 
@@ -68,11 +69,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
         return;
     }
 
-    const firmware_uri = try self.target.uefiFirmwareUri();
-
     try std.fs.cwd().makePath(self.edk2_path);
 
-    try fetch(step, firmware_uri, self.firmware_path);
+    try fetch(step, self.target.uefiFirmwareUrl(), self.firmware_path);
 
     self.firmware.path = self.firmware_path;
 
@@ -97,20 +96,62 @@ fn updateTimestampFile(self: *EDK2Step) !void {
     try timestamp_file.updateTimes(stat.atime, std.time.nanoTimestamp());
 }
 
-fn fetch(step: *Step, uri: std.Uri, destination_path: []const u8) !void {
-    const file = try std.fs.cwd().createFile(destination_path, .{});
-    defer file.close();
+fn fetch(step: *Step, url: []const u8, destination_path: []const u8) !void {
+    var failed = false;
 
-    var buffered_writer = std.io.bufferedWriter(file.writer());
-
-    downloadWithHttpClient(step.owner.allocator, uri, buffered_writer.writer()) catch |err| {
-        return step.fail("failed to fetch '{s}': {s}", .{ uri, @errorName(err) });
+    // try curl
+    helpers.runExternalBinary(
+        step.owner.allocator,
+        &.{
+            "curl",
+            "-s", // silent
+            "-f", // fail fast
+            "-o",
+            destination_path,
+            url,
+        },
+        null,
+    ) catch {
+        failed = true;
     };
 
-    try buffered_writer.flush();
+    if (!failed) return;
+    failed = false;
+
+    // try wget
+    helpers.runExternalBinary(
+        step.owner.allocator,
+        &.{
+            "wget",
+            "-q", // quiet
+            "-O",
+            destination_path,
+            url,
+        },
+        null,
+    ) catch {};
+
+    if (!failed) return;
+    failed = false;
+
+    return step.fail("failed to fetch '{s}' using either curl or wget", .{url});
+
+    // TODO: use the std http client once it stops crashing randomly
+    // const file = try std.fs.cwd().createFile(destination_path, .{});
+    // defer file.close();
+    //
+    // var buffered_writer = std.io.bufferedWriter(file.writer());
+    //
+    // downloadWithHttpClient(step.owner.allocator, url, buffered_writer.writer()) catch |err| {
+    //     return step.fail("failed to fetch '{s}': {s}", .{ url, @errorName(err) });
+    // };
+    //
+    // try buffered_writer.flush();
 }
 
-fn downloadWithHttpClient(allocator: std.mem.Allocator, uri: std.Uri, writer: anytype) !void {
+fn downloadWithHttpClient(allocator: std.mem.Allocator, url: []const u8, writer: anytype) !void {
+    const uri = try std.Uri.parse(url);
+
     var client: std.http.Client = .{ .allocator = allocator };
     defer client.deinit();
 

--- a/.build/EDK2Step.zig
+++ b/.build/EDK2Step.zig
@@ -67,7 +67,8 @@ pub fn create(b: *std.Build, target: CascadeTarget) !*EDK2Step {
 }
 
 fn make(step: *Step, prog_node: *std.Progress.Node) !void {
-    _ = prog_node;
+    var node = prog_node.start(step.name, 0);
+    defer node.end();
 
     const b = step.owner;
     const self = @fieldParentPtr(EDK2Step, "step", step);

--- a/.build/QemuStep.zig
+++ b/.build/QemuStep.zig
@@ -182,21 +182,7 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
 
     // UEFI
     if (self.uefi) {
-        const code = try std.fmt.allocPrint(
-            b.allocator,
-            "if=pflash,format=raw,unit=0,file={s},readonly=on",
-            .{self.edk2_step.?.code_firmware.getPath()},
-        );
-        const vars = try std.fmt.allocPrint(
-            b.allocator,
-            "if=pflash,format=raw,unit=1,file={s}",
-            .{self.edk2_step.?.vars_firmware.getPath()},
-        );
-
-        run_qemu.addArgs(&[_][]const u8{ "-drive", code });
-        run_qemu.addArgs(&[_][]const u8{ "-drive", vars });
-
-        //run_qemu.addArgs(&[_][]const u8{ "-bios", uefi_firmware_path });
+        run_qemu.addArgs(&[_][]const u8{ "-bios", self.edk2_step.?.firmware.getPath() });
     }
 
     // This is a hack to stop zig's progress output interfering with qemu's output

--- a/.build/helpers.zig
+++ b/.build/helpers.zig
@@ -10,3 +10,16 @@ pub fn fileExists(path: []const u8) bool {
     std.fs.cwd().access(path, .{}) catch return false;
     return true;
 }
+
+pub fn runExternalBinary(allocator: std.mem.Allocator, args: []const []const u8, cwd: ?[]const u8) !void {
+    var child = std.ChildProcess.init(args, allocator);
+    if (cwd) |c| child.cwd = c;
+
+    try child.spawn();
+    const term = try child.wait();
+
+    switch (term) {
+        .Exited => |code| if (code != 0) return error.UncleanExit,
+        else => return error.UncleanExit,
+    }
+}


### PR DESCRIPTION
This functionality is implemented but cannot be merged until https://github.com/ziglang/zig/issues/15928 is fixed.

We choose to download nightlies of the EDK2 OVMF UEFI firmware for a few reasons:

- Some distributions have _very_ old versions which have serious performance issues (~90 second start up time)
- Most distributions don't provide AARCH64 or RISC-V firmware files only x86-64
- If we are ever going to support Windows or OSX we can't assume the system will provide this firmware
- QEMU needs to be given the path to the firmware files, different systems put this file in different directories with different names