### PR TITLE
Allow architectures to omit unimplemented functionality

### DIFF
--- a/kernel/arch/aarch64/aarch64.zig
+++ b/kernel/arch/aarch64/aarch64.zig
@@ -133,7 +133,7 @@ pub const paging = struct {
         core.panic("UNIMPLEMENTED `switchToPageTable`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
     }
 
-    pub fn allocatePageTable() *PageTable {
+    pub fn allocatePageTable() error{PageAllocationFailed}!*PageTable {
         core.panic("UNIMPLEMENTED `allocatePageTable`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
     }
 };

--- a/kernel/arch/aarch64/aarch64.zig
+++ b/kernel/arch/aarch64/aarch64.zig
@@ -38,7 +38,7 @@ pub const interrupts = struct {
         asm volatile ("msr DAIFSet, #0b1111");
     }
 
-    /// Disable interrupts.
+    /// Enable interrupts.
     pub inline fn enableInterrupts() void {
         asm volatile ("msr DAIFClr, #0b1111;");
     }
@@ -57,85 +57,8 @@ pub const paging = struct {
 
     pub const standard_page_size = small_page_size;
 
-    pub inline fn largestPageSize() core.Size {
-        return large_page_size;
-    }
-
-    pub const page_sizes_available = [_]bool{
-        true,
-        true,
-        true,
-    };
-
     // TODO: Is this correct for aarch64? https://github.com/CascadeOS/CascadeOS/issues/23
     pub const higher_half = kernel.VirtualAddress.fromInt(0xffff800000000000);
-
-    // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    pub const PageTable = struct {
-        pub fn zero(self: *PageTable) void {
-            _ = self;
-            core.panic("UNIMPLEMENTED `zero`"); // TODO: Implement `zero`.
-        }
-    };
-
-    /// This function is only called during kernel init, it is required to:
-    ///   1. search the high half of the *top level* of the given page table for a free entry
-    ///   2. allocate a backing frame for it
-    ///   3. map the free entry to the fresh backing frame and ensure it is zeroed
-    ///   4. return the `VirtualRange` representing the entire virtual range that entry covers
-    pub fn getTopLevelRangeAndFillFirstLevel(page_table: *PageTable) arch.paging.MapError!kernel.VirtualRange {
-        _ = page_table;
-        core.panic("UNIMPLEMENTED `getTopLevelRangeAndFillFirstLevel`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
-
-    const MapError = arch.paging.MapError;
-
-    pub fn mapStandardRange(
-        page_table: *PageTable,
-        virtual_range: kernel.VirtualRange,
-        physical_range: kernel.PhysicalRange,
-        map_type: kernel.vmm.MapType,
-    ) MapError!void {
-        _ = map_type;
-        _ = physical_range;
-        _ = virtual_range;
-        _ = page_table;
-        core.panic("UNIMPLEMENTED `mapStandardRange`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
-
-    /// Unmaps the `virtual_range`.
-    ///
-    /// This function assumes only the architecture's `standard_page_size` is used for the mapping.
-    pub fn unmapStandardRange(
-        page_table: *PageTable,
-        virtual_range: kernel.VirtualRange,
-    ) void {
-        _ = page_table;
-        _ = virtual_range;
-        core.panic("UNIMPLEMENTED `unmapRange`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
-
-    pub fn mapRangeUseAllPageSizes(
-        page_table: *PageTable,
-        virtual_range: kernel.VirtualRange,
-        physical_range: kernel.PhysicalRange,
-        map_type: kernel.vmm.MapType,
-    ) MapError!void {
-        _ = map_type;
-        _ = physical_range;
-        _ = virtual_range;
-        _ = page_table;
-        core.panic("UNIMPLEMENTED `mapRangeUseAllPageSizes`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
-
-    pub fn switchToPageTable(page_table: *const PageTable) void {
-        _ = page_table;
-        core.panic("UNIMPLEMENTED `switchToPageTable`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
-
-    pub fn allocatePageTable() error{PageAllocationFailed}!*PageTable {
-        core.panic("UNIMPLEMENTED `allocatePageTable`"); // TODO: implement paging https://github.com/CascadeOS/CascadeOS/issues/23
-    }
 };
 
 comptime {

--- a/kernel/arch/aarch64/init.zig
+++ b/kernel/arch/aarch64/init.zig
@@ -22,15 +22,3 @@ pub fn getEarlyOutputWriter() ?aarch64.Uart.Writer {
 pub fn loadBootstrapProcessor(bootstrap_processor: *kernel.Processor) void {
     aarch64.registers.TPIDR_EL1.write(@intFromPtr(bootstrap_processor));
 }
-
-pub fn earlyArchInitialization() void {
-    core.panic("UNIMPLEMENTED `earlyArchInitialization`"); // TODO: Implement `earlyArchInitialization` https://github.com/CascadeOS/CascadeOS/issues/25
-}
-
-pub fn captureSystemInformation() void {
-    core.panic("UNIMPLEMENTED `captureSystemInformation`"); // TODO: Implement `captureSystemInformation` https://github.com/CascadeOS/CascadeOS/issues/26
-}
-
-pub fn configureSystemFeatures() void {
-    core.panic("UNIMPLEMENTED `configureSystemFeatures`"); // TODO: Implement `configureSystemFeatures` https://github.com/CascadeOS/CascadeOS/issues/27
-}


### PR DESCRIPTION
Adds a `checkSupport` function to the arch interface which checks if the interface functions are implemented or not.

If it is unimplemented, the function will panic at runtime.

If it is implemented, the function will validate the signature at compile time and do nothing at runtime.
