### PR TITLE
library/sdf: make sdf alignment independent

### DIFF
--- a/kernel/debug/symbols.zig
+++ b/kernel/debug/symbols.zig
@@ -65,8 +65,9 @@ pub fn loadSymbols() void {
                 break :sdf_slice kernel_file_slice[shdr.sh_offset..][0..shdr.sh_size];
             }
         } else break :sdf_blk;
+        var sdf_fbs = std.io.fixedBufferStream(sdf_slice);
 
-        const header = sdf.Header.read(sdf_slice) catch break :sdf_blk;
+        const header = sdf.Header.read(sdf_fbs.reader()) catch break :sdf_blk;
 
         sdf_string_table = header.stringTable(sdf_slice);
         sdf_file_table = header.fileTable(sdf_slice);
@@ -83,7 +84,7 @@ pub fn loadSymbols() void {
 pub fn getSymbol(address: usize) ?Symbol {
     if (!symbols_loaded) return null;
 
-    const start_state = sdf_location_lookup.getStartState(address);
+    const start_state = sdf_location_lookup.getStartState(address) catch return null;
 
     const location = sdf_location_program.getLocation(start_state, address) catch return null;
 

--- a/kernel/init.zig
+++ b/kernel/init.zig
@@ -176,6 +176,8 @@ fn initProcessors() linksection(kernel.info.init_code) void {
 
     var processor_id: kernel.Processor.Id = .bootstrap;
 
+    if (true) core.panic("Hello");
+
     while (processor_descriptors.next()) |processor_descriptor| : ({
         processor_id = @enumFromInt(@intFromEnum(processor_id) + 1);
     }) {

--- a/libraries/sdf/sdf.md
+++ b/libraries/sdf/sdf.md
@@ -18,11 +18,7 @@ In any future versions of this specification added fields or data structures wil
 
 The entry point to SDF that provides access to each of the specific data structures.
 
-Under normal circumstances this header would be at the start of an ELF section containing the entire SDF data.
-
 Due to the offsets contained in this header being unsigned the header must proceed all other data structures in memory.
-
-Aligned to `8` bytes.
 
 | offset | name | type | description |
 |:-|:-|:-:|:-|
@@ -51,8 +47,6 @@ An array of `FileEntry` structures containing information about each file refere
 
 Files are referenced by index.
 
-Aligned to `8` bytes.
-
 #### File Entry (`FileEntry`)
 | offset | name | type | description |
 |:-|:-|:-:|:-|
@@ -63,19 +57,14 @@ Aligned to `8` bytes.
 
 An array of instruction addresses (`leu64`) sorted in ascending order.
 
-The index of the address is the index into the location program states of the state that is an efficent start point for the location program for that address.
-
-__TODO: The above is badly written.__
-
-Aligned to `8` bytes.
+The index of the address corresponds to the index within the location program states for the state for that address,
+this serves as an efficient starting point for the location program closer to the target address.
 
 ## Location Program States
 
 An array of `LocationProgramState` structures.
 
 States are referenced by index.
-
-Aligned to `8` bytes.
 
 #### Location Program State (`LocationProgramState`)
 | offset | name | type | description |

--- a/tools/sdf_builder/FileTableBuilder.zig
+++ b/tools/sdf_builder/FileTableBuilder.zig
@@ -27,10 +27,7 @@ pub fn addFile(self: *FileTableBuilder, file_entry: sdf.FileEntry) !u64 {
 }
 
 pub fn output(self: *const FileTableBuilder, output_buffer: *std.ArrayList(u8)) !struct { u64, u64 } {
-    const offset = std.mem.alignForward(u64, output_buffer.items.len, @alignOf(sdf.FileEntry));
-    if (offset != output_buffer.items.len) {
-        try output_buffer.appendNTimes(0, offset - output_buffer.items.len);
-    }
+    const file_table_offset = output_buffer.items.len;
 
     const writer = output_buffer.writer();
 
@@ -38,7 +35,7 @@ pub fn output(self: *const FileTableBuilder, output_buffer: *std.ArrayList(u8)) 
         try file_entry.write(writer);
     }
 
-    return .{ offset, self.file_table.items.len };
+    return .{ file_table_offset, self.file_table.items.len };
 }
 
 comptime {

--- a/tools/sdf_builder/LocationLookupBuilder.zig
+++ b/tools/sdf_builder/LocationLookupBuilder.zig
@@ -36,10 +36,7 @@ pub fn addLocationLookup(
 pub fn output(self: *const LocationLookupBuilder, output_buffer: *std.ArrayList(u8)) !struct { u64, u64, u64 } {
     std.debug.assert(self.location_lookup.items.len == self.location_program_states.items.len);
 
-    const location_lookup_offset = std.mem.alignForward(u64, output_buffer.items.len, @alignOf(u64));
-    if (location_lookup_offset != output_buffer.items.len) {
-        try output_buffer.appendNTimes(0, location_lookup_offset - output_buffer.items.len);
-    }
+    const location_lookup_offset = output_buffer.items.len;
 
     const writer = output_buffer.writer();
 


### PR DESCRIPTION
This is step one towards closing https://github.com/CascadeOS/CascadeOS/issues/81.

Next sdf_builder will be expanded to support embedding a new sdf section into an elf binary which will remove the dependency on objcopy.