### PR TITLE
tool/sdf_builder: implement embedding sdf data into elf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Cascade is a general purpose operating system targeting standard desktops and la
 ## Build, testing, running
 ### Prerequisites:
 - zig master (0.12.0-dev.2811+3cafb9655)
-- objcopy (required as `zig objcopy` does not support `--add-section` https://github.com/CascadeOS/CascadeOS/issues/81)
 - qemu (optional; used for running and host testing)
 
 Run the x86_64 kernel in QEMU:

--- a/build/Kernel.zig
+++ b/build/Kernel.zig
@@ -146,10 +146,14 @@ fn create(
         }
     }
 
-    const run_sdf_builder = b.addRunArtifact(sdf_builder.release_safe_compile_step);
-    run_sdf_builder.addFileArg(kernel_exe.getEmittedBin());
-    const sdf_data_path = run_sdf_builder.addOutputFileArg("sdf.output");
-
+    const generate_sdf = b.addRunArtifact(sdf_builder.release_safe_compile_step);
+    // action
+    generate_sdf.addArg("generate");
+    // binary_input_path
+    generate_sdf.addFileArg(kernel_exe.getEmittedBin());
+    // binary_output_path
+    const sdf_data_path = generate_sdf.addOutputFileArg("sdf.output");
+    // directory_prefixes_to_strip
     generate_sdf.addArg(options.root_path);
 
     const stripped_kernel_exe = b.addObjCopy(kernel_exe.getEmittedBin(), .{


### PR DESCRIPTION
This adds an "embed" mode to sdf_builder and utilises it to embed the sdf data into the kernel removing the dependency on `objcopy --add-section`.

Closes #81